### PR TITLE
Add Email Placeholder to remove compile time error

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   <name>nav2_wfd</name>
   <version>0.0.1</version>
   <description>Wavefront Frontier Detector for ROS2 Navigation2</description>
-  <maintainer email="">Sean Regan</maintainer>
+  <maintainer email="dev@mail.com">Sean Regan</maintainer>
   <license>MIT License</license>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
When trying to compile the repo we get this error:
```
: Error(s) in package 'src/nav2_wavefront_frontier_exploration/package.xml':
Invalid email "" for person "Sean Regan"
Maintainers must have an email address
```
This pull request aims to eliminate this error. The proposed solution involves modifying the email field in the `package.xml` file to display a placeholder. 